### PR TITLE
Add Linux ARM64 build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_TIME=$(shell date +%FT%T%z)
 LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}"
 
 # Platforms
-PLATFORMS=linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64 darwin/arm64
+PLATFORMS=linux/amd64 linux/386 linux/arm64 windows/amd64 windows/386 darwin/amd64 darwin/arm64
 
 # Output directories
 DIST_DIR=bin


### PR DESCRIPTION
**Description**  
This PR updates the `Makefile` to include `linux/arm64` in the list of supported build platforms.

**Motivation**  
Support building for Linux systems running on ARM64 architecture, such as AWS Graviton or similar environments.